### PR TITLE
Add omi-kits as a subproject and use OMI's stable branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,10 @@
 [submodule "omi"]
 	path = omi
 	url = git@github.com:Microsoft/omi.git
+	branch = stable
+[submodule "opsmgr-kits"]
+	path = opsmgr-kits
+	url = git@github.com:Microsoft/SCXcore-osskits.git
 	branch = master
 [submodule "pal"]
 	path = pal


### PR DESCRIPTION
SCXcore will no longer build OMI packages instead certified omi packages will picked from omi-kits repo. This will ensure
that scx only ships package certified by the OMI team.