### PR TITLE
Add omi-kits as a subproject and use OMI's stable branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,11 @@
 [submodule "omi"]
 	path = omi
 	url = git@github.com:Microsoft/omi.git
-	branch = master
+	branch = stable
+[submodule "omi-kits"]
+	path = omi-kits
+	url = git@github.com:Microsoft/omi-kits.git
+       branch = master
 [submodule "pal"]
 	path = pal
 	url = git@github.com:Microsoft/pal.git


### PR DESCRIPTION
SCXcore will no longer build OMI packages instead certified omi packages will picked from omi-kits repo. So SCXcm will pick OMI packages from omi-kits repo.